### PR TITLE
Find IP address, if host is a non-IP address.

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -147,9 +147,36 @@ func TestParseHostsString(t *testing.T) {
 		t.Errorf("got %v\nwant %v", actualLabels, expected)
 	}
 
-	_, _, err = parseHostsString("8.8.8.")
-	expected = nil
+	_, _, err = parseHostsString("8.8.8.", "1")
 	if err == nil {
 		t.Errorf("got %v", err)
+	}
+
+	_, _, err = parseHostsString("m.root-servers.net", "1")
+	if err != nil {
+		t.Errorf("got %v", err)
+	}
+
+	actualIPs, actualLabels, err = parseHostsString("m.root-servers.net", "1")
+	expected = []string{"202.12.27.33"}
+	expected_labels = []string{"m.root-servers.net"}
+	if err != nil {
+		t.Errorf("got %v", err)
+	}
+	if actualIPs[0] != expected[0] {
+		t.Errorf("got %v\nwant %v", actualIPs, expected)
+	}
+	if actualLabels[0] != expected_labels[0] {
+		t.Errorf("got %v\nwant %v", actualLabels, expected)
+	}
+
+  actualIPs, actualLabels, err = parseHostsString("m.root-servers.net:m-root")
+	expected = []string{"202.12.27.33"}
+	expected_labels = []string{"m-root"}
+	if actualIPs[0] != expected[0] {
+		t.Errorf("got %v\nwant %v", actualIPs, expected)
+	}
+	if actualLabels[0] != expected_labels[0] {
+		t.Errorf("got %v\nwant %v", actualLabels, expected)
 	}
 }

--- a/ping_test.go
+++ b/ping_test.go
@@ -165,7 +165,7 @@ func TestParseHostsString(t *testing.T) {
 		t.Errorf("got %v\nwant %v", actualLabels, expected)
 	}
 
-  actualIPs, actualLabels, err = parseHostsString("m.root-servers.net:m-root")
+	actualIPs, actualLabels, err = parseHostsString("m.root-servers.net:m-root")
 	expected = []string{"202.12.27.33"}
 	expected_labels = []string{"m-root"}
 	if actualIPs[0] != expected[0] {

--- a/ping_test.go
+++ b/ping_test.go
@@ -152,11 +152,6 @@ func TestParseHostsString(t *testing.T) {
 		t.Errorf("got %v", err)
 	}
 
-	_, _, err = parseHostsString("m.root-servers.net", "1")
-	if err != nil {
-		t.Errorf("got %v", err)
-	}
-
 	actualIPs, actualLabels, err = parseHostsString("m.root-servers.net", "1")
 	expected = []string{"202.12.27.33"}
 	expected_labels = []string{"m.root-servers.net"}


### PR DESCRIPTION
-host オプションに IP アドレス以外の FQDN や hostname など名前解決できる文字列を指定できるようにしました。
MACKEREL_AGENT_PLUGIN_META 環境変数が設定してある状態で、名前解決出来なかった場合は、エラーとなるようにしてあります。MACKEREL_AGENT_PLUGIN_META 環境変数が指定されていない場合は、pp.Hosts リストに追加しません。
